### PR TITLE
ES population script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+canonical-model
+data/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ for an Elastic Search cluster, either running locally or on our [stage cluster](
 
 * To install ES on OSX run ```brew install elasticsearch```.
 * Run ```elasticsearch``` to boot the node.
-* To set up the ```article``` index and populate with some sample data, run ```./populate.sh```. Be warned, this will tear down the indices and rebuild them.
+* To set up the ```article``` index and populate with some sample data, run ```./setup.sh```. Be warned, this will tear down the indices and rebuild them.
 * To populate the index with sample data, fill up the ```data``` directory with as many documents as you like, fire up the service and send a request to the ```populate``` endpoint. You need to have Elastic Search running for this to work, and the data must align to the canonical data model. Any errors will be logged to the console and the service will return a 500. 
 
 ## Search

--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@ Additional samples can be added to illustration how other types of content, such
 This codebase also contains some a script to create an index and mappings
 for an Elastic Search cluster, either running locally or on our [stage cluster](mt-content-search.s.aws.economist.com).
 
-To set up the ```article``` index and populate with some sample data, run
-```./populate.sh```. Be warned, this will tear down the indices and rebuild them.
+* To install ES on OSX run ```brew install elasticsearch```.
+* Run ```elasticsearch``` to boot the node.
+* To set up the ```article``` index and populate with some sample data, run ```./populate.sh```. Be warned, this will tear down the indices and rebuild them.
+* To populate the index with sample data, fill up the ```data``` directory with as many documents as you like, fire up the service and send a request to the ```populate``` endpoint. You need to have Elastic Search running for this to work, and the data must align to the canonical data model. Any errors will be logged to the console and the service will return a 500. 
 
-To populate the index with sample data, fill up the ```data``` directory with as many documents as you like, fire up the service and send a request
-to the ```populate``` endpoint. You need to have Elastic Search running for this to work, and the data must align to the canonical data model. Any errors will be logged to the console and the service will return a 500. 
+## Search
+
+Here are some sample queries you can run after initial setup to get you going:
+
+* view mappings for the index: ```http://localhost:9200/article/_mapping```
+* search for the term "clinton": ```http://localhost:9200/article/_search?q=clinton```
+* search for the term "clinton" in ```testmap``` types: ````http://localhost:9200/article/testmap/_search?q=clinton```
+* search for the term "clinton" and return the headline and canonical URL: ````http://localhost:9200/article/testmap/_search?q=clinton&fields=headline,url.canonical```
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Economist Canonical Data Model
 
-Run the main.go file to have to API documentation and a sample article served on your localhost port 9494.
+Run the main.go file to have to API documentation and a sample article served on your localhost port 9494 at content/.
 
 This code provides full RAML documentation and a rough outline of the Go structures that encapsulate the Economist canonical data model as outlined in the spreadsheet found here: 
 https://docs.google.com/a/economist.com/spreadsheets/d/1eyFVfnu6pKlW58QGXc7cevE3o9MvNrTO40MGremJLfw/edit?usp=sharing
 
 Additional samples can be added to illustration how other types of content, such as images, lists, and blog sites, would fit into this model.
+
+# Canonical Data Model Elastic Search Mappings
+
+This codebase also contains some a script to create an index and mappings
+for an Elastic Search cluster, either running locally or on our [stage cluster](mt-content-search.s.aws.economist.com).
+
+To set up the ```article``` index and populate with some sample data, run
+```./populate.sh```. Be warned, this will tear down the indices and rebuild them.
+
+To populate the index with sample data, fill up the ```data``` directory with as many documents as you like, fire up the service and send a request
+to the ```populate``` endpoint. You need to have Elastic Search running for this to work, and the data must align to the canonical data model. Any errors will be logged to the console and the service will return a 500. 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,27 @@ for an Elastic Search cluster, either running locally or on our [stage cluster](
 Here are some sample queries you can run after initial setup to get you going:
 
 * view mappings for the index: ```http://localhost:9200/article/_mapping```
-* search for the term "clinton": ```http://localhost:9200/article/_search?q=clinton```
+* search for the term "clinton": ```http://localhost:9200/ article/_search?q=clinton```
+
 * search for the term "clinton" in ```testmap``` types: ````http://localhost:9200/article/testmap/_search?q=clinton```
-* search for the term "clinton" and return the headline and canonical URL: ````http://localhost:9200/article/testmap/_search?q=clinton&fields=headline,url.canonical```
+
+* search for the term "clinton" and return the headline and canonical URL: ```http://localhost:9200/article/testmap/_search?q=clinton&fields=headline,url.canonical```
+
+* filtered search (which doesn't order by score and so is faster and easier to cache): ```http://localhost:9200/article/_search``` make a POST request with a body of:
+
+```json
+{
+	"query": {
+		"filtered": {
+			"filter": {
+				"term": {
+					"name": "trump"
+				}
+			}
+		}
+	}
+}
+```
 
 
 

--- a/content/content.go
+++ b/content/content.go
@@ -1,0 +1,272 @@
+package content
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Content represents a canonical Content post.
+type Content struct {
+	ID                   Ref            `json:"id"`
+	TegID                string         `json:"tegID"`
+	TegType              string         `json:"tegType"`
+	Type                 string         `json:"type"`
+	SameAs               string         `json:"sameAs,omitempty"`
+	Version              string         `json:"version"`
+	RegionsAllowed       []string       `json:"regionsAllowed,omitempty"`
+	RequiresSubscription bool           `json:"requiresSubscription,omitempty"`
+	IsAccessibleForFree  bool           `json:"isAccessibleForFree,omitempty"`
+	DateCreated          ISODate        `json:"dateCreated"`
+	DateModified         ISODate        `json:"dateModified,omitempty"`
+	DatePublished        ISODate        `json:"datePublished,omitempty"`
+	DateExpired          ISODate        `json:"dateExpired,omitempty"`
+	InLanguage           string         `json:"inLanguage"`
+	URLCollection        URLCollection  `json:"url,omitempty"`
+	Headline             string         `json:"headline"`
+	SubHeadline          string         `json:"subheadline,omitempty"`
+	Description          string         `json:"description,omitempty"`
+	Byline               string         `json:"byline,omitempty"`
+	Tagline              string         `json:"tagline,omitempty"`
+	PrintEdition         Print          `json:"printEdition,omitempty"`
+	Publisher            Person         `json:"publisher,omitempty"`
+	Channel              string         `json:"channel,omitempty"`
+	IsPartOf             []Ref          `json:"isPartOf,omitempty"`
+	ArticleSection       Section        `json:"articleSection,omitempty"`
+	About                []AboutLink    `json:"about,omitempty"`
+	Genre                []string       `json:"genre,omitempty"`
+	Keywords             []string       `json:"keywords,omitempty"`
+	Ads                  Ads            `json:"ads,omitempty"`
+	Sponsor              Person         `json:"sponsor,omitempty"`
+	Audience             []Person       `json:"audience,omitempty"`
+	Comment              Ref            `json:"comment,omitempty"`
+	Images               Images         `json:"images,omitempty"`
+	Videos               Videos         `json:"videos,omitempty"`
+	Audio                Audio          `json:"audio,omitempty"`
+	AssociatedMedia      []Ref          `json:"associatedMedia,omitempty"`
+	MediaData            Media          `json:"mediaData,omitempty"`
+	Author               []Person       `json:"author,omitempty"`
+	Contributor          []Person       `json:"contributor,omitempty"`
+	CopyrightHolder      []Person       `json:"copyrightHolder,omitempty"`
+	AccountablePerson    []Person       `json:"accountablePerson,omitempty"`
+	LocationCreated      []Location     `json:"locationCreated,omitempty"`
+	SourceOrganization   []Organization `json:"sourceOrganization,omitempty"`
+	CopyrightYear        int            `json:"copyrightYear,omitempty"`
+	License              string         `json:"license,omitempty"`
+	Text                 Body           `json:"text,omitempty"`
+	Publications         []Publication  `json:"publications"`
+	ListData             List           `json:"list,omitempty"`
+}
+
+// Publication holds the overridden values for content.
+type Publication struct {
+	Headline    string `json:"headline,omitempty"`
+	SubHeadline string `json:"subHeadline,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// List represents a re-usable list of hypermedia links.
+type List struct {
+	Name        string     `json:"name,omitempty"`
+	Position    int        `json:"position,omitempty"`
+	Order       string     `json:"order,omitempty"`
+	TotalItems  int        `json:"totalItems,omitempty"`
+	Pagination  Pagination `json:"pagination,omitempty"`
+	List        Ref        `json:"list,omitempty"`
+	WithinLists []Ref      `json:"withinLists,omitempty"`
+}
+
+// URLCollection holds a collection of URLs for a piece of content.
+type URLCollection struct {
+	Canonical WebURL `json:"canonical,omitempty"`
+	Web       WebURL `json:"web,omitempty"`
+	Short     string `json:"short,omitempty"`
+	Twitter   WebURL `json:"twitter,omitempty"`
+	Alias     WebURL `json:"alias,omitempty"`
+}
+
+// NewURLCollection is factory function for URLCollection type.
+func NewURLCollection(rawURL string, shortURL string, finder PathFinder) (urlColl URLCollection) {
+	urlColl.Web = NewWebURL(rawURL, finder)
+	urlColl.Short = shortURL
+
+	return urlColl
+}
+
+// Print holds a collection of data relavent to articles in the Print Edition.
+type Print struct {
+	Headline    string `json:"headline,omitempty"`
+	SubHeadline string `json:"subHeadline,omitempty"`
+	Description string `json:"description,omitempty"`
+	Byline      string `json:"byline,omitempty"`
+	Tagline     string `json:"tagline,omitempty"`
+	Section     Ref    `json:"section,omitempty"`
+	Edition     Ref    `json:"edition,omitempty"`
+	PageStart   int    `json:"pageStart,omitempty"`
+	PageEnd     int    `json:"pageEnd,omitempty"`
+	Column      string `json:"column,omitempty"`
+}
+
+type Person struct {
+	GivenName  string `json:"givenName,omitempty"`
+	FamilyName string `json:"familyName,omitempty"`
+}
+
+// Section holds a collection of internal and external section data.
+type Section struct {
+	Internal []Ref    `json:"internal,omitempty"`
+	External []string `json:"external,omitempty"`
+}
+
+// Ads holds a collection of relevant ad data.
+type Ads struct {
+	Zone      string `json:"zone,omitempty"`
+	Site      string `json:"site,omitempty"`
+	Grapeshot Ref    `json:"grapeshot,omitempty"`
+}
+
+// Images holds a collection Images associated with the content.
+type Images struct {
+	Main    WebURL   `json:"main,omitempty"`
+	Inline  []WebURL `json:"internal,omitempty"`
+	Gallery []WebURL `json:"gallery,omitempty"`
+}
+
+// Videos holds a collection Videos associated with the content.
+type Videos struct {
+	Main    WebURL   `json:"main,omitempty"`
+	Inline  []WebURL `json:"internal,omitempty"`
+	Gallery []WebURL `json:"gallery,omitempty"`
+}
+
+// Audio holds a collection Images associated with the content.
+type Audio struct {
+	Main   WebURL   `json:"main,omitempty"`
+	Inline []WebURL `json:"internal,omitempty"`
+}
+
+// Media contains additional media information for supported media types.
+type Media struct {
+	Width          int    `json:"width,omitempty"`
+	Height         int    `json:"height,omitempty"`
+	AutoStart      bool   `json:"autostart,omitempty"`
+	EncodingFormat string `json:"encodingFormat,omitempty"`
+	Bitrate        int    `json:"bitrate,omitempty"`
+	Rendition      []Ref  `json:"rendition,omitempty"`
+}
+
+// Ads holds the format and text of the content body.
+type Body struct {
+	MediaType string `json:"mediaType,omitempty"`
+	Text      string `json:"text,omitempty"`
+}
+
+type Organization struct {
+	Address string `json:"address,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+type Location struct {
+	Address string `json:"address,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+// Pagination represents field in struct with information about range of elements in list.
+type Pagination struct {
+	PageStart int `json:"pageStart,omitempty"`
+	PageEnd   int `json:"pageEnd,omitempty"`
+}
+
+// AboutLink holds hypermedia link with a source description.
+type AboutLink struct {
+	Source string `json:"source,omitempty"`
+	Ref    Ref    `json:"ref,omitempty"`
+}
+
+// NewAboutLink is the factory function for AboutLink structure.
+func NewAboutLink(source string, ref Ref) AboutLink {
+	return AboutLink{Source: source, Ref: ref}
+}
+
+// Ref represents a consistently output Hypermedia Link.
+type Ref string
+
+// NewRef is the factory function for the Ref type.
+func NewRef(i Identifier) (ref Ref) {
+	id := i.GetID()
+	if _, err := strconv.Atoi(id); err == nil {
+		ref = Ref(fmt.Sprintf("%s%s%s", os.Getenv("API_GATEWAY_ENDPOINT"), "/mapper/id/", id))
+	} else {
+		ref = Ref(fmt.Sprintf("%s%s", os.Getenv("API_GATEWAY_ENDPOINT"), id))
+	}
+	return ref
+}
+
+// Identifier represents how to identify a piece of content or list.
+type Identifier interface {
+	GetID() string
+}
+
+// ID represents a content or list ID and is used to create hypermedia.
+// links for that ID.
+type ID string
+
+// GetID - implementation of Identifier interface.
+func (i ID) GetID() string {
+	return string(i)
+}
+
+// WebURL represents a consistently output URL.
+type WebURL string
+
+// NewWebURL is the factory function for the WebURL type.
+func NewWebURL(rawURL string, finder PathFinder) WebURL {
+	switch true {
+	case rawURL == "":
+		return WebURL(finder.GetPath())
+	case strings.HasPrefix(rawURL, "/"):
+		return WebURL(rawURL)
+	default:
+		return WebURL("/" + rawURL)
+	}
+}
+
+// PathFinder is an interface used for values to
+// tell services about their original locations if a web
+// alias cannot be found i.e. /node/<nid> for Drupal.
+type PathFinder interface {
+	GetPath() string
+}
+
+// ISODate represents ISO 8601 (RFC 3339) dates.
+// See https://en.wikipedia.org/wiki/ISO_8601.
+type ISODate string
+
+// String is the ISODate Stringer implementation.
+func (i ISODate) String() string {
+	return string(i)
+}
+
+// NewISODate is the factory function for ISODates. It can be passed
+// a timestamp int or a string, in the latter case it will try and
+// convert the string into an integer before doing the conversion.
+func NewISODate(datetime interface{}) (isoDate ISODate, err error) {
+	var data int64
+	switch datetime.(type) {
+	case int:
+		data = int64(datetime.(int))
+	case string:
+		data, err = strconv.ParseInt(datetime.(string), 10, 32)
+		if err != nil {
+			return isoDate, errors.New("unable to convert date string")
+		}
+	}
+	iso := ISODate(time.Unix(data, 0).UTC().Format(time.RFC3339))
+	if iso.String() == "1970-01-01T00:00:12Z" {
+		return isoDate, errors.New("unable to format date string")
+	}
+	return iso, nil
+}

--- a/es/populate.go
+++ b/es/populate.go
@@ -1,0 +1,66 @@
+package es
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/JonasEconomist/canonical-model/content"
+	"github.com/olivere/elastic"
+)
+
+func ReadData() error {
+	var content content.Content
+	d, err := os.Open("./data")
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	files, err := d.Readdir(-1)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Reading data from data directory")
+
+	client, err := elastic.NewClient()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Elasticsearch client booted")
+
+	for _, file := range files {
+		if file.Mode().IsRegular() {
+			data, err := ioutil.ReadFile(file.Name())
+			if err != nil {
+				log.Printf("file reading error: %v\n", err)
+				return err
+			}
+			fmt.Printf("Reading data from %s\n", file.Name())
+			if err := json.Unmarshal(data, &content); err != nil {
+				log.Printf("JSON decoding error: %v\n", err)
+				return err
+			}
+			fmt.Printf("Decoded JSON into content value\n")
+
+			_, err = client.Index().
+				Index("article").
+				Type("testmap").
+				Id(content.TegID).
+				BodyJson(content).
+				Refresh(true).
+				Do()
+			if err != nil {
+				log.Printf("Indexing error: %v\n", err)
+
+				return err
+			}
+			fmt.Println("content successfully indexed")
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
-	"strconv"
-	"strings"
-	"time"
+
+	"github.com/JonasEconomist/canonical-model/content"
+	"github.com/JonasEconomist/canonical-model/es"
 )
 
 func api(w http.ResponseWriter, r *http.Request) {
@@ -22,284 +21,36 @@ func api(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handler(w http.ResponseWriter, r *http.Request) {
+func canonical(w http.ResponseWriter, r *http.Request) {
 	bytes, err := json.Marshal(sample)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-
+	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(string(bytes)))
+}
+
+func populate(w http.ResponseWriter, r *http.Request) {
+	err := es.ReadData()
+	if err != nil {
+		log.Printf("error reading data: %v\n", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func readData(path string, f os.FileInfo, err error) error {
+	log.Fatalf("% #v\n", f)
+	return nil
 }
 
 func main() {
 	http.HandleFunc("/", api)
-	http.HandleFunc("/content/", handler)
+	http.HandleFunc("/content/", canonical)
+	http.HandleFunc("/populate/", populate)
 	http.ListenAndServe(":9494", nil)
 }
 
-// Content represents a canonical Content post.
-type Content struct {
-	ID                   Ref            `json:"id"`
-	TegID                string         `json:"tegID"`
-	TegType              string         `json:"tegType"`
-	Type                 string         `json:"type"`
-	SameAs               string         `json:"sameAs,omitempty"`
-	Version              string         `json:"version"`
-	RegionsAllowed       []string       `json:"regionsAllowed,omitempty"`
-	RequiresSubscription bool           `json:"requiresSubscription,omitempty"`
-	IsAccessibleForFree  bool           `json:"isAccessibleForFree,omitempty"`
-	DateCreated          ISODate        `json:"dateCreated"`
-	DateModified         ISODate        `json:"dateModified,omitempty"`
-	DatePublished        ISODate        `json:"datePublished,omitempty"`
-	DateExpired          ISODate        `json:"dateExpired,omitempty"`
-	InLanguage           string         `json:"inLanguage"`
-	URLCollection        URLCollection  `json:"url,omitempty"`
-	Headline             string         `json:"headline"`
-	SubHeadline          string         `json:"subheadline,omitempty"`
-	Description          string         `json:"description,omitempty"`
-	Byline               string         `json:"byline,omitempty"`
-	Tagline              string         `json:"tagline,omitempty"`
-	PrintEdition         Print          `json:"printEdition,omitempty"`
-	Publisher            Person         `json:"publisher,omitempty"`
-	Channel              string         `json:"channel,omitempty"`
-	IsPartOf             []Ref          `json:"isPartOf,omitempty"`
-	ArticleSection       Section        `json:"articleSection,omitempty"`
-	About                []AboutLink    `json:"about,omitempty"`
-	Genre                []string       `json:"genre,omitempty"`
-	Keywords             []string       `json:"keywords,omitempty"`
-	Ads                  Ads            `json:"ads,omitempty"`
-	Sponsor              Person         `json:"sponsor,omitempty"`
-	Audience             []Person       `json:"audience,omitempty"`
-	Comment              Ref            `json:"comment,omitempty"`
-	Images               Images         `json:"images,omitempty"`
-	Videos               Videos         `json:"videos,omitempty"`
-	Audio                Audio          `json:"audio,omitempty"`
-	AssociatedMedia      []Ref          `json:"associatedMedia,omitempty"`
-	MediaData            Media          `json:"mediaData,omitempty"`
-	Author               []Person       `json:"author,omitempty"`
-	Contributor          []Person       `json:"contributor,omitempty"`
-	CopyrightHolder      []Person       `json:"copyrightHolder,omitempty"`
-	AccountablePerson    []Person       `json:"accountablePerson,omitempty"`
-	LocationCreated      []Location     `json:"locationCreated,omitempty"`
-	SourceOrganization   []Organization `json:"sourceOrganization,omitempty"`
-	CopyrightYear        int            `json:"copyrightYear,omitempty"`
-	License              string         `json:"license,omitempty"`
-	Text                 Body           `json:"text,omitempty"`
-	Publications         []Publication  `json:"publications"`
-	ListData             List           `json:"list,omitempty"`
-}
-
-// Publication holds the overridden values for content.
-type Publication struct {
-	Headline    string `json:"headline,omitempty"`
-	SubHeadline string `json:"subHeadline,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
-// List represents a re-usable list of hypermedia links.
-type List struct {
-	Name        string     `json:"name,omitempty"`
-	Position    int        `json:"position,omitempty"`
-	Order       string     `json:"order,omitempty"`
-	TotalItems  int        `json:"totalItems,omitempty"`
-	Pagination  Pagination `json:"pagination,omitempty"`
-	List        Ref        `json:"list,omitempty"`
-	WithinLists []Ref      `json:"withinLists,omitempty"`
-}
-
-// URLCollection holds a collection of URLs for a piece of content.
-type URLCollection struct {
-	Canonical WebURL `json:"canonical,omitempty"`
-	Web       WebURL `json:"web,omitempty"`
-	Short     string `json:"short,omitempty"`
-	Twitter   WebURL `json:"twitter,omitempty"`
-	Alias     WebURL `json:"alias,omitempty"`
-}
-
-// NewURLCollection is factory function for URLCollection type.
-func NewURLCollection(rawURL string, shortURL string, finder PathFinder) (urlColl URLCollection) {
-	urlColl.Web = NewWebURL(rawURL, finder)
-	urlColl.Short = shortURL
-
-	return urlColl
-}
-
-// Print holds a collection of data relavent to articles in the Print Edition.
-type Print struct {
-	Headline    string `json:"headline,omitempty"`
-	SubHeadline string `json:"subHeadline,omitempty"`
-	Description string `json:"description,omitempty"`
-	Byline      string `json:"byline,omitempty"`
-	Tagline     string `json:"tagline,omitempty"`
-	Section     Ref    `json:"section,omitempty"`
-	Edition     Ref    `json:"edition,omitempty"`
-	PageStart   int    `json:"pageStart,omitempty"`
-	PageEnd     int    `json:"pageEnd,omitempty"`
-	Column      string `json:"column,omitempty"`
-}
-
-type Person struct {
-	GivenName  string `json:"givenName,omitempty"`
-	FamilyName string `json:"familyName,omitempty"`
-}
-
-// Section holds a collection of internal and external section data.
-type Section struct {
-	Internal []Ref    `json:"internal,omitempty"`
-	External []string `json:"external,omitempty"`
-}
-
-// Ads holds a collection of relevant ad data.
-type Ads struct {
-	Zone      string `json:"zone,omitempty"`
-	Site      string `json:"site,omitempty"`
-	Grapeshot Ref    `json:"grapeshot,omitempty"`
-}
-
-// Images holds a collection Images associated with the content.
-type Images struct {
-	Main    WebURL   `json:"main,omitempty"`
-	Inline  []WebURL `json:"internal,omitempty"`
-	Gallery []WebURL `json:"gallery,omitempty"`
-}
-
-// Videos holds a collection Videos associated with the content.
-type Videos struct {
-	Main    WebURL   `json:"main,omitempty"`
-	Inline  []WebURL `json:"internal,omitempty"`
-	Gallery []WebURL `json:"gallery,omitempty"`
-}
-
-// Audio holds a collection Images associated with the content.
-type Audio struct {
-	Main   WebURL   `json:"main,omitempty"`
-	Inline []WebURL `json:"internal,omitempty"`
-}
-
-// Media contains additional media information for supported media types.
-type Media struct {
-	Width          int    `json:"width,omitempty"`
-	Height         int    `json:"height,omitempty"`
-	AutoStart      bool   `json:"autostart,omitempty"`
-	EncodingFormat string `json:"encodingFormat,omitempty"`
-	Bitrate        int    `json:"bitrate,omitempty"`
-	Rendition      []Ref  `json:"rendition,omitempty"`
-}
-
-// Ads holds the format and text of the content body.
-type Body struct {
-	MediaType string `json:"mediaType,omitempty"`
-	Text      string `json:"text,omitempty"`
-}
-
-type Organization struct {
-	Address string `json:"address,omitempty"`
-	Name    string `json:"name,omitempty"`
-}
-
-type Location struct {
-	Address string `json:"address,omitempty"`
-	Name    string `json:"name,omitempty"`
-}
-
-// Pagination represents field in struct with information about range of elements in list.
-type Pagination struct {
-	PageStart int `json:"pageStart,omitempty"`
-	PageEnd   int `json:"pageEnd,omitempty"`
-}
-
-// AboutLink holds hypermedia link with a source description.
-type AboutLink struct {
-	Source string `json:"source,omitempty"`
-	Ref    Ref    `json:"ref,omitempty"`
-}
-
-// NewAboutLink is the factory function for AboutLink structure.
-func NewAboutLink(source string, ref Ref) AboutLink {
-	return AboutLink{Source: source, Ref: ref}
-}
-
-// Ref represents a consistently output Hypermedia Link.
-type Ref string
-
-// NewRef is the factory function for the Ref type.
-func NewRef(i Identifier) (ref Ref) {
-	id := i.GetID()
-	if _, err := strconv.Atoi(id); err == nil {
-		ref = Ref(fmt.Sprintf("%s%s%s", os.Getenv("API_GATEWAY_ENDPOINT"), "/mapper/id/", id))
-	} else {
-		ref = Ref(fmt.Sprintf("%s%s", os.Getenv("API_GATEWAY_ENDPOINT"), id))
-	}
-	return ref
-}
-
-// Identifier represents how to identify a piece of content or list.
-type Identifier interface {
-	GetID() string
-}
-
-// ID represents a content or list ID and is used to create hypermedia.
-// links for that ID.
-type ID string
-
-// GetID - implementation of Identifier interface.
-func (i ID) GetID() string {
-	return string(i)
-}
-
-// WebURL represents a consistently output URL.
-type WebURL string
-
-// NewWebURL is the factory function for the WebURL type.
-func NewWebURL(rawURL string, finder PathFinder) WebURL {
-	switch true {
-	case rawURL == "":
-		return WebURL(finder.GetPath())
-	case strings.HasPrefix(rawURL, "/"):
-		return WebURL(rawURL)
-	default:
-		return WebURL("/" + rawURL)
-	}
-}
-
-// PathFinder is an interface used for values to
-// tell services about their original locations if a web
-// alias cannot be found i.e. /node/<nid> for Drupal.
-type PathFinder interface {
-	GetPath() string
-}
-
-// ISODate represents ISO 8601 (RFC 3339) dates.
-// See https://en.wikipedia.org/wiki/ISO_8601.
-type ISODate string
-
-// String is the ISODate Stringer implementation.
-func (i ISODate) String() string {
-	return string(i)
-}
-
-// NewISODate is the factory function for ISODates. It can be passed
-// a timestamp int or a string, in the latter case it will try and
-// convert the string into an integer before doing the conversion.
-func NewISODate(datetime interface{}) (isoDate ISODate, err error) {
-	var data int64
-	switch datetime.(type) {
-	case int:
-		data = int64(datetime.(int))
-	case string:
-		data, err = strconv.ParseInt(datetime.(string), 10, 32)
-		if err != nil {
-			return isoDate, errors.New("unable to convert date string")
-		}
-	}
-	iso := ISODate(time.Unix(data, 0).UTC().Format(time.RFC3339))
-	if iso.String() == "1970-01-01T00:00:12Z" {
-		return isoDate, errors.New("unable to format date string")
-	}
-	return iso, nil
-}
-
-var sample = Content{
+var sample = content.Content{
 	ID:                   "http://mt-content.stage.s.aws.economist.com/mapper/id/21697812",
 	TegID:                "thpjrusqjuiub84fu6t3h3n6oivvaa1b",
 	TegType:              "article",
@@ -312,7 +63,7 @@ var sample = Content{
 	DateModified:         "2015-12-30T15:49:20Z",
 	DatePublished:        "2015-12-30T15:49:20Z",
 	InLanguage:           "en",
-	URLCollection: URLCollection{
+	URLCollection: content.URLCollection{
 		Canonical: "http://www.economist.com/news/21697812-worlds-most-valuable-company-reported-its-first-year-year-quarterly-revenue-decline",
 		Web:       "/news/21697812-worlds-most-valuable-company-reported-its-first-year-year-quarterly-revenue-decline",
 		Short:     "bit.ly/21697812",
@@ -320,24 +71,24 @@ var sample = Content{
 	Headline:    "Shake it off",
 	SubHeadline: "The future of Apple",
 	Description: "The worldâ€™s most valuable company needs another mega hit",
-	PrintEdition: Print{
+	PrintEdition: content.Print{
 		SubHeadline: "The worldâ€™s most valuable company",
 		Edition:     "http://mt-content.stage.s.aws.economist.com/mapper/id/21697795",
 		Section:     "http://mt-content.stage.s.aws.economist.com/sections/77",
 		PageStart:   25,
 		PageEnd:     26,
 	},
-	IsPartOf: []Ref{
-		NewRef(ID("/lists/print")),
-		NewRef(ID("/lists/sections")),
+	IsPartOf: []content.Ref{
+		content.NewRef(content.ID("/lists/print")),
+		content.NewRef(content.ID("/lists/sections")),
 	},
-	ArticleSection: Section{
-		Internal: []Ref{
-			NewRef(ID("/sections/34")),
+	ArticleSection: content.Section{
+		Internal: []content.Ref{
+			content.NewRef(content.ID("/sections/34")),
 		},
 	},
-	About: []AboutLink{
-		AboutLink{
+	About: []content.AboutLink{
+		content.AboutLink{
 			Source: "Topics",
 			Ref:    "http://mt-content.stage.s.aws.economist.com/lists/topics/21697816",
 		},
@@ -351,41 +102,41 @@ var sample = Content{
 		"Business",
 		"Apple",
 	},
-	Ads: Ads{
+	Ads: content.Ads{
 		Zone:      "kjdu",
 		Site:      "LASN",
 		Grapeshot: "http://mt-content.stage.s.aws.economist.com/external/grapeshot?url=http%3A%2F%2Fwww.economist.com%2Fnode%2F21697812",
 	},
-	Sponsor: Person{
+	Sponsor: content.Person{
 		GivenName:  "Mark",
 		FamilyName: "Brincat",
 	},
-	Comment: NewRef(ID("http://www.economist.com/node/21697812/comments#comments")),
-	Images: Images{
+	Comment: content.NewRef(content.ID("http://www.economist.com/node/21697812/comments#comments")),
+	Images: content.Images{
 		Main: "http://cdn.static-economist.com/sites/default/files/images/2016/04/articles/body/20160430_wbc249_0.png",
-		Inline: []WebURL{
+		Inline: []content.WebURL{
 			"http://cdn.static-economist.com/sites/default/files/images/2016/04/articles/body/20160430_wbc249_0.png",
 		},
 	},
-	Author: []Person{
-		Person{
+	Author: []content.Person{
+		content.Person{
 			FamilyName: "M.S.R",
 		},
 	},
-	Text: Body{
+	Text: content.Body{
 		MediaType: "text/html",
 		Text:      "<p>OUR product pipeline has amazing innovations in store.</p>",
 	},
-	Publications: []Publication{
-		Publication{
+	Publications: []content.Publication{
+		content.Publication{
 			SubHeadline: "The worldâ€™s most valuable company",
 		},
 	},
-	ListData: List{
-		WithinLists: []Ref{
-			NewRef(ID("/mapper/id/21697795")),
-			NewRef(ID("/sections/77")),
-			NewRef(ID("/sections/34")),
+	ListData: content.List{
+		WithinLists: []content.Ref{
+			content.NewRef(content.ID("/mapper/id/21697795")),
+			content.NewRef(content.ID("/sections/77")),
+			content.NewRef(content.ID("/sections/34")),
 		},
 	},
 }

--- a/setup.sh
+++ b/setup.sh
@@ -14,8 +14,27 @@ if [ $? != 0 ]; then
     exit -1
 fi
 
+echo "WARNING, this script will delete the 'article' index and re-index all data!"
+echo "Press Control-C to cancel this operation."
+echo
+echo "Press [Enter] to continue."
+read
+
+# Delete the old index.
+curl -s -XDELETE "$ADDRESS/article" > /dev/null
+
+# Create the next index from mapping file.
+echo "Creating 'article' index..."
+curl -s -XPOST "$ADDRESS/article" -d@$(dirname $0)/elasticsearchmap.json
+curl -s "$ADDRESS/article/_health?wait_for_status=yellow&timeout=10s" > /dev/null
+echo
+echo "Done creating 'article' index."
+
+echo
+echo "Indexing data..."
+
 echo "Indexing articles..."
-curl -s -XPOST "$ADDRESS/article/testmap/21697812" -d'{
+curl -s -XPOST "$ADDRESS/article/testmap/abcjrusqjuiub84fu6t3h3n6oivvaa1b" -d'{
   "id": "http://mt-content.stage.s.aws.economist.com/mapper/id/21697812",
   "tegID": "abcjrusqjuiub84fu6t3h3n6oivvaa1b",
   "tegType": "article",
@@ -82,7 +101,7 @@ curl -s -XPOST "$ADDRESS/article/testmap/21697812" -d'{
 }'
 
 echo
-curl -s -XPOST "$ADDRESS/article/testmap/21707839" -d'{
+curl -s -XPOST "$ADDRESS/article/testmap/thpjrusqjuiub84fu6t3h3n6oivvaa1b" -d'{
   "id": "http://mt-content.stage.s.aws.economist.com/mapper/id/21707839",
   "tegID": "thpjrusqjuiub84fu6t3h3n6oivvaa1b",
   "tegType": "blog",
@@ -142,7 +161,7 @@ curl -s -XPOST "$ADDRESS/article/testmap/21707839" -d'{
 }'
 
 echo
-curl -s -XPOST "$ADDRESS/article/testmap/21701829" -d'{
+curl -s -XPOST "$ADDRESS/article/testmap/efgjrusqjuiub84fu6t3h3n6oivvaa1b" -d'{
   "id": "http://mt-content.stage.s.aws.economist.com/collections/21701829",
   "tegID": "efgjrusqjuiub84fu6t3h3n6oivvaa1b",
   "tegType": "storyCollection",
@@ -181,7 +200,7 @@ curl -s -XPOST "$ADDRESS/article/testmap/21701829" -d'{
 }'
 
 echo
-curl -s -XPOST "$ADDRESS/article/testmap/34" -d'{
+curl -s -XPOST "$ADDRESS/article/testmaphijjrusqjuiub84fu6t3h3n6oivvaa1b" -d'{
   "id": "http://mt-content.stage.s.aws.economist.com/sections/34",
   "tegID": "hijjrusqjuiub84fu6t3h3n6oivvaa1b",
   "tegType": "section",


### PR DESCRIPTION
- Renames the population script to `setup.sh`.
- Adds a handler to populate the index with files from the `data` directory.
- Adds instructions and some sample queries to the README.
- Extracts the content into a package for use across other packages.
